### PR TITLE
使ZLToolKit支持作为其他项目的子项目构建

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,6 @@ endif()
 set(ENABLE_OPENSSL ON CACHE BOOL "enable openssl")
 set(ENABLE_MYSQL ON CACHE BOOL "enable mysql")
 
-
 #查找openssl是否安装
 find_package(OpenSSL QUIET)
 if(OPENSSL_FOUND AND ENABLE_OPENSSL)
@@ -70,8 +69,6 @@ endif()
 
 #打印库文件
 message(STATUS "将链接依赖库:${LINK_LIB_LIST}")
-#引用头文件路径
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
 #使能c++11
 set(CMAKE_CXX_STANDARD 11)
 
@@ -83,6 +80,7 @@ endif()
 #编译动态库
 if(NOT IOS AND NOT ANDROID AND NOT WIN32)
     add_library(${CMAKE_PROJECT_NAME}_shared SHARED ${SRC_LIST})
+    target_include_directories(${CMAKE_PROJECT_NAME}_shared PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
     target_link_libraries(${CMAKE_PROJECT_NAME}_shared ${LINK_LIB_LIST})
     set_target_properties(${CMAKE_PROJECT_NAME}_shared PROPERTIES OUTPUT_NAME "${CMAKE_PROJECT_NAME}")
     install(TARGETS ${CMAKE_PROJECT_NAME}_shared  ARCHIVE DESTINATION ${INSTALL_PATH_LIB} LIBRARY DESTINATION ${INSTALL_PATH_LIB})
@@ -90,6 +88,8 @@ endif()
 
 #编译静态库
 add_library(${CMAKE_PROJECT_NAME}_static STATIC ${SRC_LIST})
+#引用头文件路径
+target_include_directories(${CMAKE_PROJECT_NAME}_static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
 set_target_properties(${CMAKE_PROJECT_NAME}_static PROPERTIES OUTPUT_NAME "${CMAKE_PROJECT_NAME}")
 #安装静态库至系统目录
 install(TARGETS ${CMAKE_PROJECT_NAME}_static ARCHIVE DESTINATION ${INSTALL_PATH_LIB})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 ﻿project(ZLToolKit)
 cmake_minimum_required(VERSION 3.1.3)
-
 #加载自定义模块
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 #设置库文件路径
@@ -19,8 +18,8 @@ endif()
 
 #安装目录
 if(WIN32)
-    set(INSTALL_PATH_LIB $ENV{HOME}/${CMAKE_PROJECT_NAME}/lib)
-    set(INSTALL_PATH_INCLUDE $ENV{HOME}/${CMAKE_PROJECT_NAME}/include)
+    set(INSTALL_PATH_LIB $ENV{HOME}/${PROJECT_NAME}/lib)
+    set(INSTALL_PATH_INCLUDE $ENV{HOME}/${PROJECT_NAME}/include)
 else()
     set(INSTALL_PATH_LIB lib)
     set(INSTALL_PATH_INCLUDE include)
@@ -79,20 +78,20 @@ endif()
 
 #编译动态库
 if(NOT IOS AND NOT ANDROID AND NOT WIN32)
-    add_library(${CMAKE_PROJECT_NAME}_shared SHARED ${SRC_LIST})
-    target_include_directories(${CMAKE_PROJECT_NAME}_shared PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
-    target_link_libraries(${CMAKE_PROJECT_NAME}_shared ${LINK_LIB_LIST})
-    set_target_properties(${CMAKE_PROJECT_NAME}_shared PROPERTIES OUTPUT_NAME "${CMAKE_PROJECT_NAME}")
-    install(TARGETS ${CMAKE_PROJECT_NAME}_shared  ARCHIVE DESTINATION ${INSTALL_PATH_LIB} LIBRARY DESTINATION ${INSTALL_PATH_LIB})
+    add_library(${PROJECT_NAME}_shared SHARED ${SRC_LIST})
+    target_include_directories(${PROJECT_NAME}_shared PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+    target_link_libraries(${PROJECT_NAME}_shared ${LINK_LIB_LIST})
+    set_target_properties(${PROJECT_NAME}_shared PROPERTIES OUTPUT_NAME "${PROJECT_NAME}")
+    install(TARGETS ${PROJECT_NAME}_shared  ARCHIVE DESTINATION ${INSTALL_PATH_LIB} LIBRARY DESTINATION ${INSTALL_PATH_LIB})
 endif()
 
 #编译静态库
-add_library(${CMAKE_PROJECT_NAME}_static STATIC ${SRC_LIST})
+add_library(${PROJECT_NAME}_static STATIC ${SRC_LIST})
 #引用头文件路径
-target_include_directories(${CMAKE_PROJECT_NAME}_static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
-set_target_properties(${CMAKE_PROJECT_NAME}_static PROPERTIES OUTPUT_NAME "${CMAKE_PROJECT_NAME}")
+target_include_directories(${PROJECT_NAME}_static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+set_target_properties(${PROJECT_NAME}_static PROPERTIES OUTPUT_NAME "${PROJECT_NAME}")
 #安装静态库至系统目录
-install(TARGETS ${CMAKE_PROJECT_NAME}_static ARCHIVE DESTINATION ${INSTALL_PATH_LIB})
+install(TARGETS ${PROJECT_NAME}_static ARCHIVE DESTINATION ${INSTALL_PATH_LIB})
 
 
 #测试程序

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,9 +7,9 @@ foreach(TEST_SRC ${TEST_SRC_LIST})
     add_executable(${TEST_EXE_NAME} ${TEST_SRC})
 
     if(ANDROID OR IOS OR WIN32)
-        target_link_libraries(${TEST_EXE_NAME} ${CMAKE_PROJECT_NAME}_static ${LINK_LIB_LIST})
+        target_link_libraries(${TEST_EXE_NAME} ${PROJECT_NAME}_static ${LINK_LIB_LIST})
     else()
-        target_link_libraries(${TEST_EXE_NAME} ${CMAKE_PROJECT_NAME}_shared ${LINK_LIB_LIST} pthread)
+        target_link_libraries(${TEST_EXE_NAME} ${PROJECT_NAME}_shared ${LINK_LIB_LIST} pthread)
     endif()
 
 endforeach(TEST_SRC ${TEST_SRC_LIST})


### PR DESCRIPTION
更改cmake后，可用**cmake-module**中的**FetchContent**把ZLToolKit作为其他项目的子项目
注：FetchContent 需要CMake 3.14以上