### PR TITLE
修复删除文件夹失败的问题

### DIFF
--- a/src/Util/File.cpp
+++ b/src/Util/File.cpp
@@ -35,6 +35,7 @@ using namespace toolkit;
 
 #if defined(_WIN32)
 
+#define S_ISREG(model) ((model) & _S_IFREG)
 int mkdir(const char *path, int mode) {
     return _mkdir(path);
 }

--- a/src/Util/File.cpp
+++ b/src/Util/File.cpp
@@ -16,6 +16,7 @@
 #include <limits.h>
 #endif // WIN32
 
+#include <sys/types.h>
 #include <sys/stat.h>
 #include "File.h"
 #include "util.h"
@@ -29,6 +30,7 @@ using namespace toolkit;
 #define    _unlink    unlink
 #define    _rmdir    rmdir
 #define    _access    access
+#define    _stat    stat
 #endif
 
 #if defined(_WIN32)
@@ -157,12 +159,11 @@ bool File::is_dir(const char *path) {
 
 //判断是否为常规文件
 bool File::is_file(const char *path) {
-    auto fp = fopen(path, "rb");
-    if (!fp) {
-        return false;
+    struct stat fi;
+    if(0 == _stat(path,&fi)){
+        return S_ISREG(fi.st_mode);
     }
-    fclose(fp);
-    return true;
+    return false;
 }
 
 //判断是否是特殊目录

--- a/src/Util/File.cpp
+++ b/src/Util/File.cpp
@@ -160,7 +160,11 @@ bool File::is_dir(const char *path) {
 
 //判断是否为常规文件
 bool File::is_file(const char *path) {
+#if defined(_WIN32)
+    struct _stat fi;
+#else
     struct stat fi;
+#endif// _WIN32
     if(0 == _stat(path,&fi)){
         return S_ISREG(fi.st_mode);
     }


### PR DESCRIPTION
删除文件时，如果是一个目录会判断为一个文件，导致删除失败（https://github.com/ZLMediaKit/ZLMediaKit/issues/1485），修复此问题，我在linux 上试过了是可以的，**不知道windows/mac 是否可以**