### PR TITLE
兼容sendmmsg在低版本的glibc编译

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,25 @@
 ﻿project(ZLToolKit)
 cmake_minimum_required(VERSION 3.1.3)
+
+include(CheckStructHasMember)
+include(CheckSymbolExists)
+
+list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
+check_struct_has_member("struct mmsghdr" msg_hdr sys/socket.h HAVE_MMSG_HDR)
+check_symbol_exists(sendmmsg sys/socket.h HAVE_SENDMMSG_API)
+check_symbol_exists(recvmmsg sys/socket.h HAVE_RECVMMSG_API)
+
+if(HAVE_MMSG_HDR)
+    add_definitions(-DHAVE_MMSG_HDR)
+endif()
+if(HAVE_SENDMMSG_API)
+    add_definitions(-DHAVE_SENDMMSG_API)
+endif()
+if(HAVE_RECVMMSG_API)
+    add_definitions(-DHAVE_RECVMMSG_API)
+endif()
+
+
 #加载自定义模块
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 #设置库文件路径
@@ -46,6 +66,7 @@ endif()
 
 set(ENABLE_OPENSSL ON CACHE BOOL "enable openssl")
 set(ENABLE_MYSQL ON CACHE BOOL "enable mysql")
+
 
 #查找openssl是否安装
 find_package(OpenSSL QUIET)

--- a/src/Network/BufferSock.cpp
+++ b/src/Network/BufferSock.cpp
@@ -13,6 +13,7 @@
 #include "Util/logger.h"
 #include "Util/uv_errno.h"
 
+#if defined(__linux__) || defined(__linux)
 
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
@@ -48,6 +49,8 @@ static inline int recvmmsg(int fd, struct mmsghdr *mmsg,
         return syscall(__NR_recvmmsg, fd, mmsg, vlen, flags, timeout);
 }
 #endif
+
+#endif// defined(__linux__) || defined(__linux)
 
 namespace toolkit {
 

--- a/src/Network/BufferSock.cpp
+++ b/src/Network/BufferSock.cpp
@@ -13,6 +13,42 @@
 #include "Util/logger.h"
 #include "Util/uv_errno.h"
 
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#ifndef MSG_WAITFORONE
+#define MSG_WAITFORONE  0x10000
+#endif
+
+#ifndef HAVE_MMSG_HDR
+struct mmsghdr {
+        struct msghdr   msg_hdr;
+        unsigned        msg_len;
+};
+#endif
+
+#ifndef HAVE_SENDMMSG_API
+#include <unistd.h>
+#include <sys/syscall.h>
+static inline int sendmmsg(int fd, struct mmsghdr *mmsg,
+                unsigned vlen, unsigned flags)
+{
+        return syscall(__NR_sendmmsg, fd, mmsg, vlen, flags);
+}
+#endif
+
+#ifndef HAVE_RECVMMSG_API
+#include <unistd.h>
+#include <sys/syscall.h>
+static inline int recvmmsg(int fd, struct mmsghdr *mmsg,
+                unsigned vlen, unsigned flags, struct timespec *timeout)
+{
+        return syscall(__NR_recvmmsg, fd, mmsg, vlen, flags, timeout);
+}
+#endif
+
 namespace toolkit {
 
 StatisticImp(BufferList)


### PR DESCRIPTION
CentOS6由于glibc版本较低，自从加了sendmmsg后无法成功编译，但有实际的系统调用，增加sendmmsg的相关定义即可