### PR TITLE
Patch 12

### DIFF
--- a/src/Util/local_time.cpp
+++ b/src/Util/local_time.cpp
@@ -1,0 +1,129 @@
+//
+// Created by alex on 2022/5/29.
+//
+
+/*
+ * Copyright (c) 2018, Salvatore Sanfilippo <antirez at gmail dot com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <time.h>
+
+/* This is a safe version of localtime() which contains no locks and is
+ * fork() friendly. Even the _r version of localtime() cannot be used safely
+ * in Redis. Another thread may be calling localtime() while the main thread
+ * forks(). Later when the child process calls localtime() again, for instance
+ * in order to log something to the Redis log, it may deadlock: in the copy
+ * of the address space of the forked process the lock will never be released.
+ *
+ * This function takes the timezone 'tz' as argument, and the 'dst' flag is
+ * used to check if daylight saving time is currently in effect. The caller
+ * of this function should obtain such information calling tzset() ASAP in the
+ * main() function to obtain the timezone offset from the 'timezone' global
+ * variable. To obtain the daylight information, if it is currently active or not,
+ * one trick is to call localtime() in main() ASAP as well, and get the
+ * information from the tm_isdst field of the tm structure. However the daylight
+ * time may switch in the future for long running processes, so this information
+ * should be refreshed at safe times.
+ *
+ * Note that this function does not work for dates < 1/1/1970, it is solely
+ * designed to work with what time(NULL) may return, and to support Redis
+ * logging of the dates, it's not really a complete implementation. */
+namespace toolkit {
+static int _daylight_active;
+
+int get_daylight_active() {
+    return _daylight_active;
+}
+
+static int is_leap_year(time_t year) {
+    if (year % 4)
+        return 0; /* A year not divisible by 4 is not leap. */
+    else if (year % 100)
+        return 1; /* If div by 4 and not 100 is surely leap. */
+    else if (year % 400)
+        return 0; /* If div by 100 *and* not by 400 is not leap. */
+    else
+        return 1; /* If div by 100 and 400 is leap. */
+}
+
+void no_locks_localtime(struct tm *tmp, time_t t) {
+    const time_t secs_min = 60;
+    const time_t secs_hour = 3600;
+    const time_t secs_day = 3600 * 24;
+
+    t -= timezone; /* Adjust for timezone. */
+    t += 3600 * get_daylight_active(); /* Adjust for daylight time. */
+    time_t days = t / secs_day; /* Days passed since epoch. */
+    time_t seconds = t % secs_day; /* Remaining seconds. */
+
+    tmp->tm_isdst = get_daylight_active();
+    tmp->tm_hour = seconds / secs_hour;
+    tmp->tm_min = (seconds % secs_hour) / secs_min;
+    tmp->tm_sec = (seconds % secs_hour) % secs_min;
+
+    /* 1/1/1970 was a Thursday, that is, day 4 from the POV of the tm structure
+     * where sunday = 0, so to calculate the day of the week we have to add 4
+     * and take the modulo by 7. */
+    tmp->tm_wday = (days + 4) % 7;
+
+    /* Calculate the current year. */
+    tmp->tm_year = 1970;
+    while (1) {
+        /* Leap years have one day more. */
+        time_t days_this_year = 365 + is_leap_year(tmp->tm_year);
+        if (days_this_year > days)
+            break;
+        days -= days_this_year;
+        tmp->tm_year++;
+    }
+    tmp->tm_yday = days; /* Number of day of the current year. */
+
+    /* We need to calculate in which month and day of the month we are. To do
+     * so we need to skip days according to how many days there are in each
+     * month, and adjust for the leap year that has one more day in February. */
+    int mdays[12] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
+    mdays[1] += is_leap_year(tmp->tm_year);
+
+    tmp->tm_mon = 0;
+    while (days >= mdays[tmp->tm_mon]) {
+        days -= mdays[tmp->tm_mon];
+        tmp->tm_mon++;
+    }
+
+    tmp->tm_mday = days + 1; /* Add 1 since our 'days' is zero-based. */
+    tmp->tm_year -= 1900; /* Surprisingly tm_year is year-1900. */
+}
+
+void local_time_init() {
+    /* Obtain timezone and daylight info. */
+    tzset(); /* Now 'timezome' global is populated. */
+    time_t t = time(NULL);
+    struct tm *aux = localtime(&t);
+    _daylight_active = aux->tm_isdst;
+}
+} // namespace toolkit

--- a/src/Util/local_time.h
+++ b/src/Util/local_time.h
@@ -1,0 +1,15 @@
+//
+// Created by alex on 2022/5/29.
+//
+
+#ifndef UTIL_LOCALTIME_H
+#define UTIL_LOCALTIME_H
+#include <time.h>
+
+namespace toolkit {
+void no_locks_localtime(struct tm *tmp, time_t t);
+void local_time_init();
+int get_daylight_active();
+
+} // namespace toolkit
+#endif // UTIL_LOCALTIME_H

--- a/src/Util/logger.cpp
+++ b/src/Util/logger.cpp
@@ -15,6 +15,7 @@
 #include "onceToken.h"
 #include "File.h"
 #include "NoticeCenter.h"
+#include "local_time.h"
 
 #if defined(_WIN32)
 #include "strptime_win.h"
@@ -78,6 +79,7 @@ INSTANCE_IMP(Logger, exeName())
 Logger::Logger(const string &loggerName) {
     _logger_name = loggerName;
     _last_log = std::make_shared<LogContext>();
+    local_time_init();
 }
 
 Logger::~Logger() {

--- a/src/Util/util.cpp
+++ b/src/Util/util.cpp
@@ -17,6 +17,7 @@
 #include <random>
 
 #include "util.h"
+#include "local_time.h"
 #include "File.h"
 #include "onceToken.h"
 #include "logger.h"
@@ -400,7 +401,7 @@ struct tm getLocalTime(time_t sec) {
 #ifdef _WIN32
     localtime_s(&tm, &sec);
 #else
-    localtime_r(&sec, &tm);
+    no_locks_localtime(&tm, sec);
 #endif //_WIN32
     return tm;
 }


### PR DESCRIPTION
简单封装了redis的自有实现的无锁的localtime

localtime_r是线程安全的，但是，对如下两种情况并不安全，甚至会引发死锁。

（1）信号处理函数调用localtime： 假如进程调用localtime，已经获取全局锁，且并没有释放。此时，如果进程接收到信号，在信号处理函数也调用了localtime，就会造成死锁

（2）多线程下fork： 在多线程下，若线程A调用localtime，已经获取全局锁，尚未释放锁。此时，假如线程B调用了fork，并且在子进程也调用localtime，也会造成死锁，导致子进程一直被hang住