### PR TITLE
提供一个虚基类, 可以通过虚继承的方式自己设置日志的flag标志位

### DIFF
--- a/src/Util/logger.cpp
+++ b/src/Util/logger.cpp
@@ -177,9 +177,9 @@ static inline const char *getFunctionName(const char *func) {
 #endif
 }
 
-LogContext::LogContext(LogLevel level, const char *file, const char *function, int line, const char *module_name)
+LogContext::LogContext(LogLevel level, const char *file, const char *function, int line, const char *module_name, const char *flag)
         : _level(level), _line(line), _file(getFileName(file)), _function(getFunctionName(function)),
-          _module_name(module_name) {
+          _module_name(module_name), _flag(flag) {
     gettimeofday(&_tv, nullptr);
     _thread_name = getThreadName();
 }
@@ -197,8 +197,8 @@ const string &LogContext::str() {
 
 static string s_module_name = exeName(false);
 
-LogContextCapture::LogContextCapture(Logger &logger, LogLevel level, const char *file, const char *function, int line) :
-        _ctx(new LogContext(level, file, function, line, s_module_name.c_str())), _logger(logger) {
+LogContextCapture::LogContextCapture(Logger &logger, LogLevel level, const char *file, const char *function, int line, const char *flag) :
+        _ctx(new LogContext(level, file, function, line, s_module_name.c_str(), flag)), _logger(logger) {
 }
 
 LogContextCapture::LogContextCapture(const LogContextCapture &that) : _ctx(that._ctx), _logger(that._logger) {
@@ -376,9 +376,9 @@ void LogChannel::format(const Logger &logger, ostream &ost, const LogContextPtr 
 
     if (enable_detail) {
 #if defined(_WIN32)
-        ost << ctx->_module_name <<"[" << GetCurrentProcessId() << "-" << ctx->_thread_name;
+        ost << (!ctx->_flag.empty()? ctx->_flag: ctx->_module_name) <<"[" << GetCurrentProcessId() << "-" << ctx->_thread_name;
 #else
-        ost << logger.getName() << "[" << getpid() << "-" << ctx->_thread_name;
+        ost << (!ctx->_flag.empty()? ctx->_flag: logger.getName()) << "[" << getpid() << "-" << ctx->_thread_name;
 #endif
         ost << "] " << ctx->_file << ":" << ctx->_line << " " << ctx->_function << " | ";
     }

--- a/src/Util/logger.h
+++ b/src/Util/logger.h
@@ -371,7 +371,7 @@ protected:
     }
     void setLogFlag(const char *flag) { _log_flag = flag; }
 private:
-    const char *_log_flag;
+    const char *_log_flag = "";
 };
 
 class LoggerWrapper {


### PR DESCRIPTION
任何类需要虚继承BaseLogFlagInterface后才能使用以下的宏
TraceF
DebugF
InfoF
WarnF
ErrorF

当设置了flag后, 在每行日志头部会显示flag替代logger name, 如果没有设置flag则默认显示logger name.