### PR TITLE
1. 修改日志的输出格式,输出更清晰

### DIFF
--- a/src/Network/sockutil.cpp
+++ b/src/Network/sockutil.cpp
@@ -193,12 +193,30 @@ int SockUtil::setBroadcast(int fd, bool on) {
     return ret;
 }
 
-int SockUtil::setKeepAlive(int fd, bool on) {
+int SockUtil::setKeepAlive(int fd, bool on, int interval, int idle, int times) {
+    // Enable/disable the keep-alive option
     int opt = on ? 1 : 0;
     int ret = setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, (char *) &opt, static_cast<socklen_t>(sizeof(opt)));
     if (ret == -1) {
         TraceL << "setsockopt SO_KEEPALIVE failed";
     }
+#if !defined(_WIN32)
+    // Set the keep-alive parameters
+    if (on && interval > 0 && ret != -1) {
+        ret = setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, (char *) &idle, static_cast<socklen_t>(sizeof(idle)));
+        if (ret == -1) {
+            TraceL << "setsockopt TCP_KEEPIDLE failed";
+        }
+        ret = setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, (char *) &interval, static_cast<socklen_t>(sizeof(interval)));
+        if (ret == -1) {
+            TraceL << "setsockopt TCP_KEEPINTVL failed";
+        }
+        ret = setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, (char *) &times, static_cast<socklen_t>(sizeof(times)));
+        if (ret == -1) {
+            TraceL << "setsockopt TCP_KEEPCNT failed";
+        }
+    }
+#endif
     return ret;
 }
 

--- a/src/Network/sockutil.cpp
+++ b/src/Network/sockutil.cpp
@@ -202,6 +202,12 @@ int SockUtil::setKeepAlive(int fd, bool on, int interval, int idle, int times) {
         TraceL << "setsockopt SO_KEEPALIVE failed";
     }
 #if !defined(_WIN32)
+#if !defined(SOL_TCP) && defined(IPPROTO_TCP)
+  #define SOL_TCP IPPROTO_TCP
+#endif
+#if !defined(TCP_KEEPIDLE) && defined(TCP_KEEPALIVE)
+  #define TCP_KEEPIDLE TCP_KEEPALIVE
+#endif
     // Set the keep-alive parameters
     if (on && interval > 0 && ret != -1) {
         ret = setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, (char *) &idle, static_cast<socklen_t>(sizeof(idle)));

--- a/src/Network/sockutil.cpp
+++ b/src/Network/sockutil.cpp
@@ -21,6 +21,7 @@
 #include "Util/onceToken.h"
 #if defined (__APPLE__)
 #include <ifaddrs.h>
+#include <netinet/tcp.h>
 #endif
 using namespace std;
 

--- a/src/Network/sockutil.h
+++ b/src/Network/sockutil.h
@@ -47,6 +47,9 @@ int close(int fd);
 #endif // defined(_WIN32)
 
 #define SOCKET_DEFAULT_BUF_SIZE (256 * 1024)
+#define TCP_KEEPALIVE_INTERVAL 30
+#define TCP_KEEPALIVE_PROBE_TIMES 9
+#define TCP_KEEPALIVE_TIME 120
 
 //套接字工具类，封装了socket、网络的一些基本操作
 class SockUtil {
@@ -148,9 +151,12 @@ public:
      * 是否开启TCP KeepAlive特性
      * @param fd socket fd号
      * @param on 是否开启该特性
+     * @param idle keepalive空闲时间
+     * @param interval keepalive探测时间间隔
+     * @param times keepalive探测次数
      * @return 0代表成功，-1为失败
      */
-    static int setKeepAlive(int fd, bool on = true);
+    static int setKeepAlive(int fd, bool on = true, int interval = TCP_KEEPALIVE_INTERVAL, int idle = TCP_KEEPALIVE_TIME, int times = TCP_KEEPALIVE_PROBE_TIMES);
 
     /**
      * 是否开启FD_CLOEXEC特性(多进程相关)

--- a/src/Util/logger.cpp
+++ b/src/Util/logger.cpp
@@ -374,11 +374,11 @@ void LogChannel::format(const Logger &logger, ostream &ost, const LogContextPtr 
 
     if (enable_detail) {
 #if defined(_WIN32)
-        ost << (!ctx->_flag.empty()? ctx->_flag: ctx->_module_name) <<"[" << GetCurrentProcessId() << "-" << ctx->_thread_name;
+    ost << "[" << GetCurrentProcessId() << "-" << ctx->_thread_name << "] [" << (!ctx->_flag.empty()? ctx->_flag: ctx->_module_name);
 #else
-        ost << (!ctx->_flag.empty()? ctx->_flag: logger.getName()) << "[" << getpid() << "-" << ctx->_thread_name;
+    ost << "[" << getpid() << "-" << ctx->_thread_name << "] [" << (!ctx->_flag.empty()? ctx->_flag: logger.getName());
 #endif
-        ost << "] " << ctx->_file << ":" << ctx->_line << " " << ctx->_function << " | ";
+    ost << "] " << ctx->_file << ":" << ctx->_line << " " << ctx->_function << " | ";
     }
 
     ost << ctx->str();

--- a/src/Util/util.cpp
+++ b/src/Util/util.cpp
@@ -639,5 +639,27 @@ string getEnv(const string &key) {
     return value ? value : "";
 }
 
+template <typename... Args>
+std::string str_format(const string &format, Args... args) {
+  // Calculate the buffer size
+  auto size_buf = snprintf(nullptr, 0, format.c_str(), args ...) + 1;
+  // Allocate the buffer
+#if __cplusplus >= 201703L
+  // C++17
+  auto buf = std::make_unique<char[]>(size_buf);
+#else
+  // C++11
+  std::unique_ptr<char[]> buf(new(std::nothrow) char[size_buf]);
+#endif
+  // Check if the allocation is successful
+  if (buf == nullptr) {
+    return {};
+  }
+  // Fill the buffer with formatted string
+  auto result = snprintf(buf.get(), size_buf, format.c_str(), args ...);
+  // Return the formatted string
+  return std::string(buf.get(), buf.get() + result);
+}
+
 }  // namespace toolkit
 

--- a/src/Util/util.cpp
+++ b/src/Util/util.cpp
@@ -640,7 +640,7 @@ string getEnv(const string &key) {
 }
 
 template <typename... Args>
-std::string str_format(const string &format, Args... args) {
+string str_format(const string &format, Args... args) {
   // Calculate the buffer size
   auto size_buf = snprintf(nullptr, 0, format.c_str(), args ...) + 1;
   // Allocate the buffer
@@ -649,7 +649,7 @@ std::string str_format(const string &format, Args... args) {
   auto buf = std::make_unique<char[]>(size_buf);
 #else
   // C++11
-  std::unique_ptr<char[]> buf(new(std::nothrow) char[size_buf]);
+  unique_ptr<char[]> buf(new(nothrow) char[size_buf]);
 #endif
   // Check if the allocation is successful
   if (buf == nullptr) {
@@ -658,7 +658,7 @@ std::string str_format(const string &format, Args... args) {
   // Fill the buffer with formatted string
   auto result = snprintf(buf.get(), size_buf, format.c_str(), args ...);
   // Return the formatted string
-  return std::string(buf.get(), buf.get() + result);
+  return string(buf.get(), buf.get() + result);
 }
 
 }  // namespace toolkit

--- a/src/Util/util.h
+++ b/src/Util/util.h
@@ -197,6 +197,9 @@ bool isIP(const char *str);
 bool start_with(const std::string &str, const std::string &substr);
 //字符串是否以xx结尾
 bool end_with(const std::string &str, const std::string &substr);
+//拼接格式字符串
+template<typename... Args>
+std::string str_format(const std::string &format, Args... args);
 
 #ifndef bzero
 #define bzero(ptr,size)  memset((ptr),0,(size));


### PR DESCRIPTION
1. 修改日志的输出格式,输出更清晰
2. 完善setKeepAlive, 因为如果拉取http-ts或者http-flv流时,如果启用了keepAlive, 那么使用内核参数明显不合适, 需要单独设置参数.
3. 增加了一个字符串格式华的函数, 毕竟有时候复杂的字符串拼接使用[<<]不是很方便