### PR TITLE
修复 toolkit:replace 可能出现无限递归的情况

### DIFF
--- a/src/Util/util.cpp
+++ b/src/Util/util.cpp
@@ -237,16 +237,16 @@ std::string trim(std::string &&s, const string &chars) {
     return std::move(s);
 }
 
-void replace(string &str, const string &old_str, const string &new_str) {
+void replace(string &str, const string &old_str, const string &new_str,std::string::size_type b_pos) {
     if (old_str.empty() || old_str == new_str) {
         return;
     }
-    auto pos = str.find(old_str);
+    auto pos = str.find(old_str,b_pos);
     if (pos == string::npos) {
         return;
     }
     str.replace(pos, old_str.size(), new_str);
-    replace(str, old_str, new_str);
+    replace(str, old_str, new_str,pos + new_str.length());
 }
 
 bool start_with(const string &str, const string &substr) {

--- a/src/Util/util.h
+++ b/src/Util/util.h
@@ -190,7 +190,7 @@ std::string strToLower(std::string &&str);
 std::string &strToUpper(std::string &str);
 std::string strToUpper(std::string &&str);
 //替换子字符串
-void replace(std::string &str, const std::string &old_str, const std::string &new_str) ;
+void replace(std::string &str, const std::string &old_str, const std::string &new_str, std::string::size_type b_pos = 0) ;
 //判断是否为ip
 bool isIP(const char *str);
 //字符串是否以xx开头


### PR DESCRIPTION
```toolkit:replace``` 当参数 ```new_str```包含```old_str``` 的时候回出现无限递归

如:
```c++
string test = "m=audio 0 RTP/AVP 0\r\n";
toolkit:replace(test,"RTP/AVP","RTP/AVP/TCP");
```
将出现无限递归导致溢出