### PR TITLE
windows 内部端口占多问题

### DIFF
--- a/src/Network/sockutil.cpp
+++ b/src/Network/sockutil.cpp
@@ -107,7 +107,7 @@ static inline bool support_ipv6_l() {
     return true;
 }
 
-static inline bool support_ipv6() {
+bool SockUtil::support_ipv6() {
     static auto flag = support_ipv6_l();
     return flag;
 }

--- a/src/Network/sockutil.h
+++ b/src/Network/sockutil.h
@@ -288,6 +288,7 @@ public:
      */
     static uint16_t get_peer_port(int sock);
 
+    static bool support_ipv6();
     /**
      * 线程安全的in_addr转ip字符串
      */

--- a/src/Poller/EventPoller.cpp
+++ b/src/Poller/EventPoller.cpp
@@ -13,6 +13,7 @@
 #include "Util/util.h"
 #include "Util/uv_errno.h"
 #include "Util/TimeTicker.h"
+#include "Util/NoticeCenter.h"
 #include "Network/sockutil.h"
 
 #if defined(HAS_EPOLL)
@@ -461,8 +462,11 @@ void EventPollerPool::preferCurrentThread(bool flag) {
     _prefer_current_thread = flag;
 }
 
+const std::string EventPollerPool::kOnStarted = "kBroadcastEventPollerPoolStarted";
+
 EventPollerPool::EventPollerPool() {
     auto size = addPoller("event poller", s_pool_size, ThreadPool::PRIORITY_HIGHEST, true, s_enable_cpu_affinity);
+    NoticeCenter::Instance().emitEvent(kOnStarted, *this, size);
     InfoL << "EventPoller created size: " << size;
 }
 

--- a/src/Poller/EventPoller.h
+++ b/src/Poller/EventPoller.h
@@ -231,6 +231,7 @@ private:
 class EventPollerPool : public std::enable_shared_from_this<EventPollerPool>, public TaskExecutorGetterImp {
 public:
     using Ptr = std::shared_ptr<EventPollerPool>;
+    static const std::string kOnStarted;
     ~EventPollerPool() = default;
 
     /**

--- a/src/Poller/PipeWrap.cpp
+++ b/src/Poller/PipeWrap.cpp
@@ -32,11 +32,15 @@ namespace toolkit {
 
 PipeWrap::PipeWrap() {
 #if defined(_WIN32)
-    auto listener_fd = SockUtil::listen(0, "127.0.0.1");
+    string localip("127.0.0.1");
+    if (SockUtil::support_ipv6()) {
+        localip = "::1";
+    }
+    auto listener_fd = SockUtil::listen(0, (const char *)localip.c_str());
     checkFD(listener_fd)
     SockUtil::setNoBlocked(listener_fd,false);
     auto localPort = SockUtil::get_local_port(listener_fd);
-    _pipe_fd[1] = SockUtil::connect("127.0.0.1", localPort,false);
+    _pipe_fd[1] = SockUtil::connect((const char *)localip.c_str(), localPort,false);
     checkFD(_pipe_fd[1])
     _pipe_fd[0] = (int)accept(listener_fd, nullptr, nullptr);
     checkFD(_pipe_fd[0])

--- a/src/Thread/ThreadPool.h
+++ b/src/Thread/ThreadPool.h
@@ -29,10 +29,11 @@ public:
         PRIORITY_HIGHEST
     };
 
-    ThreadPool(int num = 1, Priority priority = PRIORITY_HIGHEST, bool auto_run = true, bool set_affinity = true) {
+    ThreadPool(int num = 1, Priority priority = PRIORITY_HIGHEST, bool auto_run = true, bool set_affinity = true,
+               const std::string &pool_name = "thread pool") {
         _thread_num = num;
-        _on_setup = [priority, set_affinity](int index) {
-            std::string name = "thread pool " + std::to_string(index);
+        _on_setup = [pool_name, priority, set_affinity](int index) {
+            std::string name = pool_name + ' ' + std::to_string(index);
             setPriority(priority);
             setThreadName(name.data());
             if (set_affinity) {

--- a/src/Util/util.cpp
+++ b/src/Util/util.cpp
@@ -271,7 +271,7 @@ void usleep(int micro_seconds) {
 }
 
 int gettimeofday(struct timeval *tp, void *tzp) {
-    auto now_stamp = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    auto now_stamp = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
     tp->tv_sec = (decltype(tp->tv_sec))(now_stamp / 1000000LL);
     tp->tv_usec = now_stamp % 1000000LL;
     return 0;
@@ -351,7 +351,7 @@ static inline uint64_t getCurrentMicrosecondOrigin() {
     gettimeofday(&tv, nullptr);
     return tv.tv_sec * 1000000LL + tv.tv_usec;
 #else
-    return  std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    return  std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
 #endif
 }
 


### PR DESCRIPTION
1、Windows 的PipeWrap内部采用ipv6，减少端口占用资源
