### PR TITLE
udp socket支持软绑定目标地址

### DIFF
--- a/src/Network/Socket.h
+++ b/src/Network/Socket.h
@@ -454,9 +454,10 @@ public:
      * 绑定udp 目标地址，后续发送时就不用再单独指定了
      * @param dst_addr 目标地址
      * @param addr_len 目标地址长度
+     * @param soft_bind 是否软绑定，软绑定时不调用udp connect接口，只保存目标地址信息，发送时再传递到sendto函数
      * @return 是否成功
      */
-    bool bindPeerAddr(const struct sockaddr *dst_addr, socklen_t addr_len = 0);
+    bool bindPeerAddr(const struct sockaddr *dst_addr, socklen_t addr_len = 0, bool soft_bind = false);
 
     /**
      * 设置发送flags
@@ -528,6 +529,9 @@ private:
     bool _err_emit = false;
     //是否启用网速统计
     bool _enable_speed = false;
+    // udp发送目标地址
+    std::shared_ptr<struct sockaddr_storage> _udp_send_dst;
+
     //接收速率统计
     BytesSpeed _recv_speed;
     //发送速率统计


### PR DESCRIPTION
硬绑定(udp connect)目标地址后可能导致收不到其他地址的报文，所以新增一种可以指定目标发送地址的机制， 这样在调用Socket::send接口时不用指定目标地址，同时又不会导致收不到其他地址的报文。
此特性主要是为了解决rtsp服务器发送rtp(udp)给nat内的播放器失败的问题。