### PR TITLE
shotdown函数how参数使用SD_BOTH宏替换

### DIFF
--- a/src/Network/Socket.h
+++ b/src/Network/Socket.h
@@ -126,7 +126,7 @@ public:
         unsetSocketOfIOS(_fd);
 #endif //OS_IPHONE
         // 停止socket收发能力
-        ::shutdown(_fd, SHUT_RDWR);
+        ::shutdown(_fd, SD_BOTH);
         close(_fd);
     }
 

--- a/src/Network/Socket.h
+++ b/src/Network/Socket.h
@@ -126,7 +126,11 @@ public:
         unsetSocketOfIOS(_fd);
 #endif //OS_IPHONE
         // 停止socket收发能力
+        #if defined(_WIN32)
         ::shutdown(_fd, SD_BOTH);
+        #else
+        ::shutdown(_fd, SHUT_RDWR);
+        #endif
         close(_fd);
     }
 

--- a/src/Network/sockutil.h
+++ b/src/Network/sockutil.h
@@ -39,9 +39,6 @@ namespace toolkit {
 #ifndef socklen_t
 #define socklen_t int
 #endif //!socklen_t
-#ifndef SHUT_RDWR
-#define SHUT_RDWR 2
-#endif //!SHUT_RDWR
 int ioctl(int fd, long cmd, u_long *ptr);
 int close(int fd);
 #endif // defined(_WIN32)


### PR DESCRIPTION
在引入usrsctp库时SHUT_RDWR被重新定义为3
shutdown 在winsock.h中有默认宏定义SD_BOTH