### PR TITLE
修复Udp数据已关闭流，由于最后几帧数据传入又重新创建session对象

### DIFF
--- a/src/Network/UdpServer.cpp
+++ b/src/Network/UdpServer.cpp
@@ -292,13 +292,16 @@ Session::Ptr UdpServer::createSession(const PeerIdType &id, const Buffer::Ptr &b
                 lock_guard<std::recursive_mutex> lck(*strong_self->_session_mutex);
                 strong_self->_session_map->erase(id);
                 //0.5s后自动删除
-                strong_self->_session_erase_map->emplace(id,std::make_unique<Timer>(0.5f,
+                strong_self->_session_erase_map->emplace(
+                    id,
+                    std::unique_ptr<Timer>(std::move(new Timer(
+                        0.5f,
                     [weak_self,id]() -> bool {
                             auto strong_self = weak_self.lock();
                             strong_self->_session_erase_map->erase(id);
                         return false;
                     },
-                    _poller));
+                    _poller))));
             });
 
             // 获取会话强应用

--- a/src/Network/UdpServer.cpp
+++ b/src/Network/UdpServer.cpp
@@ -278,7 +278,7 @@ Session::Ptr UdpServer::createSession(const PeerIdType &id, const Buffer::Ptr &b
             //收到非本peer fd的数据，让server去派发此数据到合适的session对象
             strong_self->onRead_l(false, id, buf, addr, addr_len);
         });
-        socket->setOnErr([weak_self, weak_session, id, cls](const SockException &err) {
+        socket->setOnErr([weak_self, weak_session, id, cls,this](const SockException &err) {
             // 在本函数作用域结束时移除会话对象
             // 目的是确保移除会话前执行其 onError 函数
             // 同时避免其 onError 函数抛异常时没有移除会话对象

--- a/src/Network/UdpServer.h
+++ b/src/Network/UdpServer.h
@@ -111,6 +111,8 @@ private:
     //cloned server共享主server的session map，防止数据在不同server间漂移
     std::shared_ptr<std::recursive_mutex> _session_mutex;
     std::shared_ptr<std::unordered_map<PeerIdType, SessionHelper::Ptr> > _session_map;
+    //避免关闭流时由于最后几帧数据导致再次重新创建session
+    std::shared_ptr<std::unordered_map<PeerIdType,std::unique_ptr<Timer>>> _session_erase_map;
     //主server持有cloned server的引用
     std::unordered_map<EventPoller *, Ptr> _cloned_server;
     std::function<SessionHelper::Ptr(const UdpServer::Ptr &, const Socket::Ptr &)> _session_alloc;


### PR DESCRIPTION
目前是通过0.5s自动删除的map，来判断这几帧数据是不是当前关闭的流。