### PR TITLE
修复同一个SockNum对象在一个EventPoller中有机率先进行delEvent 后进行addEvent的问题

### DIFF
--- a/src/Poller/EventPoller.h
+++ b/src/Poller/EventPoller.h
@@ -37,6 +37,7 @@ public:
     using Ptr = std::shared_ptr<EventPoller>;
     using PollEventCB = std::function<void(int event)>;
     using PollCompleteCB = std::function<void(bool success)>;
+    using PollAttachingCB = std::function<void(bool success)>;
     using DelayTask = TaskCancelableImp<uint64_t(void)>;
 
     typedef enum {
@@ -60,9 +61,10 @@ public:
      * @param fd 监听的文件描述符
      * @param event 事件类型，例如 Event_Read | Event_Write
      * @param cb 事件回调functional
+     * @param attachingCb attach在异步处理中的标志位设置functional
      * @return -1:失败，0:成功
      */
-    int addEvent(int fd, int event, PollEventCB cb);
+    int addEvent(int fd, int event, PollEventCB cb, PollAttachingCB attachingCb = nullptr);
 
     /**
      * 删除事件监听


### PR DESCRIPTION
#### 典型场景:
频繁地进行调用openRtpServer和closeRtpServer, 当响应处理同一个TcpServer open和close操作的EventPoller不同时， 有机率因为close请求响应的EventPoller先对SockNum进行了delEvent，而该EventPoller的addEvent操作后执行(因为此时该EventPoller处理该SockNum对象的addEvent一定是异步的)，导致SockNum和对应的端口永远不被释放。