### PR TITLE
禁用SSLv2、SSLv3、TLSv1、TLSv1.1不安全协议

### DIFF
--- a/src/Util/SSLBox.cpp
+++ b/src/Util/SSLBox.cpp
@@ -211,11 +211,22 @@ void SSL_Initor::setupCtx(SSL_CTX *ctx) {
     ssloptions |= SSL_OP_NO_RENEGOTIATION;
 #endif
 
+#ifdef SSL_OP_NO_SSLv2 
     ssloptions |= SSL_OP_NO_SSLv2;
+#endif
+
+#ifdef SSL_OP_NO_SSLv3 
     ssloptions |= SSL_OP_NO_SSLv3;
+#endif
+
+#ifdef SSL_OP_NO_TLSv1 
     ssloptions |= SSL_OP_NO_TLSv1;
+#endif
+
+#ifdef SSL_OP_NO_TLSv1_1 /* openssl 1.0.1 */
     ssloptions |= SSL_OP_NO_TLSv1_1;
-    
+#endif
+
     SSL_CTX_set_options(ctx, ssloptions);
 
 #endif //defined(ENABLE_OPENSSL)

--- a/src/Util/SSLBox.cpp
+++ b/src/Util/SSLBox.cpp
@@ -210,6 +210,12 @@ void SSL_Initor::setupCtx(SSL_CTX *ctx) {
 #ifdef SSL_OP_NO_RENEGOTIATION /* openssl 1.1.0 */
     ssloptions |= SSL_OP_NO_RENEGOTIATION;
 #endif
+
+    ssloptions |= SSL_OP_NO_SSLv2;
+    ssloptions |= SSL_OP_NO_SSLv3;
+    ssloptions |= SSL_OP_NO_TLSv1;
+    ssloptions |= SSL_OP_NO_TLSv1_1;
+    
     SSL_CTX_set_options(ctx, ssloptions);
 
 #endif //defined(ENABLE_OPENSSL)


### PR DESCRIPTION
由于端口扫出了 启用 SSLv2、SSLv3、TLSv1、TLSv1.1这些不安全协议