### PR TITLE
兼容Alpine镜像打包

### DIFF
--- a/src/Util/util.cpp
+++ b/src/Util/util.cpp
@@ -505,7 +505,9 @@ string getThreadName() {
     string ret;
     ret.resize(32);
     auto tid = pthread_self();
-    pthread_getname_np(tid, (char *) ret.data(), ret.size());
+#if defined(__GLIBC__)
+    pthread_getname_np(tid, (char*)ret.data(), ret.size());
+#endif
     if (ret[0]) {
         ret.resize(strlen(ret.data()));
         return ret;


### PR DESCRIPTION
出现这个错误是因为 pthread_getname_np 函数在 glibc 2.12 版本之后才被添加进来，而 Alpine Linux 发行版使用的是 musl libc，它没有实现该函数的兼容接口

 FROM frolvlad/alpine-glibc:alpine-3.14