### PR TITLE
[fix] 修复 toolkit::Any::empty() 返回always true 问题

### DIFF
--- a/src/Util/util.h
+++ b/src/Util/util.h
@@ -472,7 +472,7 @@ public:
     }
 
     operator bool() const { return _data.operator bool(); }
-    bool empty() const { return !bool(); }
+    bool empty() const { return !operator bool(); }
 
     void reset() {
         _type = nullptr;


### PR DESCRIPTION
fix Incorrect empty() Implementation in toolkit::Any Always Returns True. (#263 )