### PR TITLE
fix: 修复GOP cache overflow之后删除的只剩一个gop的问题

### DIFF
--- a/src/Util/RingBuffer.h
+++ b/src/Util/RingBuffer.h
@@ -179,7 +179,7 @@ public:
         if (++_size > _max_size) {
             // GOP缓存溢出  [AUTO-TRANSLATED:1cd0ddc4]
             //GOP cache overflow
-            while (_data_cache.size() > 1) {
+            while ((_size > _max_size) && (_data_cache.size() > 1)) {
                 //先尝试清除老的GOP缓存  [AUTO-TRANSLATED:a01422a1]
                 //Try to clear the old GOP cache first
                 popFrontGop();


### PR DESCRIPTION
在重新编译之后修改while判断条件之后测试带音频的startRecordTask 接口生成的视频不会发生视频时长缺失的问题