### PR TITLE
quic需要显示的设置UDP buff, 否则工作不正常

### DIFF
--- a/src/Network/BufferSock.cpp
+++ b/src/Network/BufferSock.cpp
@@ -615,6 +615,8 @@ SocketRecvBuffer::Ptr SocketRecvBuffer::create(bool is_udp) {
 }
 
 SocketRecvBuffer::Ptr SocketRecvBuffer::create(bool is_udp, size_t packet_count, size_t buffer_capacity) {
+    packet_count = packet_count ? packet_count : kPacketCount;
+    buffer_capacity = buffer_capacity ? buffer_capacity : kBufferCapacity;
 #if defined(__linux) || defined(__linux__)
     if (is_udp) {
         return std::make_shared<SocketRecvmmsgBuffer>(packet_count, buffer_capacity);

--- a/src/Network/BufferSock.cpp
+++ b/src/Network/BufferSock.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <assert.h>
+#include <limits>
 #include "BufferSock.h"
 #include "Util/logger.h"
 #include "Util/uv_errno.h"
@@ -622,7 +623,7 @@ SocketRecvBuffer::Ptr SocketRecvBuffer::create(bool is_udp, size_t packet_count,
     auto use_default = false;
     if (packet_count < 1 || buffer_capacity < 2) {
         use_default = true;
-    } else if (packet_count > SIZE_MAX / buffer_capacity) {
+    } else if (packet_count > std::numeric_limits<size_t>::max() / buffer_capacity) {
         use_default = true;
     } else if (packet_count * buffer_capacity > kMaxTotalBufferBytes) {
         use_default = true;

--- a/src/Network/BufferSock.cpp
+++ b/src/Network/BufferSock.cpp
@@ -623,7 +623,7 @@ SocketRecvBuffer::Ptr SocketRecvBuffer::create(bool is_udp, size_t packet_count,
     auto use_default = false;
     if (packet_count < 1 || buffer_capacity < 2) {
         use_default = true;
-    } else if (packet_count > std::numeric_limits<size_t>::max() / buffer_capacity) {
+    } else if (packet_count > (std::numeric_limits<size_t>::max)() / buffer_capacity) {
         use_default = true;
     } else if (packet_count * buffer_capacity > kMaxTotalBufferBytes) {
         use_default = true;

--- a/src/Network/BufferSock.cpp
+++ b/src/Network/BufferSock.cpp
@@ -620,7 +620,9 @@ SocketRecvBuffer::Ptr SocketRecvBuffer::create(bool is_udp, size_t packet_count,
     buffer_capacity = buffer_capacity ? buffer_capacity : kBufferCapacity;
 
     auto use_default = false;
-    if (packet_count > SIZE_MAX / buffer_capacity) {
+    if (packet_count < 1 || buffer_capacity < 2) {
+        use_default = true;
+    } else if (packet_count > SIZE_MAX / buffer_capacity) {
         use_default = true;
     } else if (packet_count * buffer_capacity > kMaxTotalBufferBytes) {
         use_default = true;

--- a/src/Network/BufferSock.cpp
+++ b/src/Network/BufferSock.cpp
@@ -611,12 +611,16 @@ static constexpr auto kPacketCount = 32;
 static constexpr auto kBufferCapacity = 4 * 1024u;
 
 SocketRecvBuffer::Ptr SocketRecvBuffer::create(bool is_udp) {
+    return create(is_udp, kPacketCount, kBufferCapacity);
+}
+
+SocketRecvBuffer::Ptr SocketRecvBuffer::create(bool is_udp, size_t packet_count, size_t buffer_capacity) {
 #if defined(__linux) || defined(__linux__)
     if (is_udp) {
-        return std::make_shared<SocketRecvmmsgBuffer>(kPacketCount, kBufferCapacity);
+        return std::make_shared<SocketRecvmmsgBuffer>(packet_count, buffer_capacity);
     }
 #endif
-    return std::make_shared<SocketRecvFromBuffer>(kPacketCount * kBufferCapacity);
+    return std::make_shared<SocketRecvFromBuffer>(packet_count * buffer_capacity);
 }
 
 } //toolkit

--- a/src/Network/BufferSock.cpp
+++ b/src/Network/BufferSock.cpp
@@ -609,6 +609,7 @@ private:
 
 static constexpr auto kPacketCount = 32;
 static constexpr auto kBufferCapacity = 4 * 1024u;
+static constexpr auto kMaxTotalBufferBytes = 64 * 1024u * 1024u;
 
 SocketRecvBuffer::Ptr SocketRecvBuffer::create(bool is_udp) {
     return create(is_udp, kPacketCount, kBufferCapacity);
@@ -617,6 +618,20 @@ SocketRecvBuffer::Ptr SocketRecvBuffer::create(bool is_udp) {
 SocketRecvBuffer::Ptr SocketRecvBuffer::create(bool is_udp, size_t packet_count, size_t buffer_capacity) {
     packet_count = packet_count ? packet_count : kPacketCount;
     buffer_capacity = buffer_capacity ? buffer_capacity : kBufferCapacity;
+
+    auto use_default = false;
+    if (packet_count > SIZE_MAX / buffer_capacity) {
+        use_default = true;
+    } else if (packet_count * buffer_capacity > kMaxTotalBufferBytes) {
+        use_default = true;
+    }
+
+    if (use_default) {
+        WarnL << "Invalid recv buffer config, fallback to defaults: packet_count="
+              << packet_count << ", buffer_capacity=" << buffer_capacity;
+        packet_count = kPacketCount;
+        buffer_capacity = kBufferCapacity;
+    }
 #if defined(__linux) || defined(__linux__)
     if (is_udp) {
         return std::make_shared<SocketRecvmmsgBuffer>(packet_count, buffer_capacity);

--- a/src/Network/BufferSock.h
+++ b/src/Network/BufferSock.h
@@ -81,6 +81,7 @@ public:
     virtual struct sockaddr_storage &getAddress(size_t index) = 0;
 
     static Ptr create(bool is_udp);
+    static Ptr create(bool is_udp, size_t packet_count, size_t buffer_capacity);
 };
 
 }

--- a/src/Network/Socket.cpp
+++ b/src/Network/Socket.cpp
@@ -276,14 +276,18 @@ bool Socket::attachEvent(const SockNum::Ptr &sock) {
 
     // tcp客户端或udp  [AUTO-TRANSLATED:00c16e7f]
     //TCP client or UDP
-    auto read_buffer = _poller->getSharedBuffer(sock->type() == SockNum::Sock_UDP);
-    auto result = _poller->addEvent(sock->rawFd(), EventPoller::Event_Read | EventPoller::Event_Error | EventPoller::Event_Write, [weak_self, sock, read_buffer](int event) {
+    auto result = _poller->addEvent(sock->rawFd(), EventPoller::Event_Read | EventPoller::Event_Error | EventPoller::Event_Write, [weak_self, sock](int event) {
         auto strong_self = weak_self.lock();
         if (!strong_self) {
             return;
         }
 
         if (event & EventPoller::Event_Read) {
+            // Some transports install a socket-specific recv buffer during
+            // session setup after attachEvent() has already been registered, so
+            // the read path must resolve the current buffer here instead of
+            // capturing the poller's shared buffer in the lambda.
+            auto read_buffer = strong_self->getReadBuffer(sock->type() == SockNum::Sock_UDP);
             strong_self->onRead(sock, read_buffer);
         }
         if (event & EventPoller::Event_Write) {
@@ -321,7 +325,9 @@ ssize_t Socket::onRead(const SockNum::Ptr &sock, const SocketRecvBuffer::Ptr &bu
                 if (sock->type() == SockNum::Sock_TCP) {
                     emitErr(toSockException(err));
                 } else {
-                    WarnL << "Recv err on udp socket[" << sock->rawFd() << "]: " << uv_strerror(err);
+                    if (!(err == UV_ECONNREFUSED && _ignore_udp_conn_refused.load(std::memory_order_acquire))) {
+                        WarnL << "Recv err on udp socket[" << sock->rawFd() << "]: " << uv_strerror(err);
+                    }
                 }
             }
             return ret;
@@ -1019,6 +1025,25 @@ bool Socket::bindPeerAddr(const struct sockaddr *dst_addr, socklen_t addr_len, b
 
 void Socket::setSendFlags(int flags) {
     _sock_flags = flags;
+}
+
+void Socket::setReadBuffer(const SocketRecvBuffer::Ptr &buffer) {
+    _read_buffer = buffer;
+    _has_custom_read_buffer.store(static_cast<bool>(_read_buffer), std::memory_order_release);
+}
+
+void Socket::setIgnoreUdpConnRefused(bool ignore) {
+    _ignore_udp_conn_refused.store(ignore, std::memory_order_release);
+}
+
+SocketRecvBuffer::Ptr Socket::getReadBuffer(bool is_udp) {
+    // Most sockets keep using the poller's shared recv buffer. Custom buffers
+    // are installed during socket setup, so the hot path only needs a cheap
+    // flag check here.
+    if (!_has_custom_read_buffer.load(std::memory_order_acquire)) {
+        return _poller->getSharedBuffer(is_udp);
+    }
+    return _read_buffer;
 }
 
 ///////////////SockSender///////////////////

--- a/src/Network/Socket.cpp
+++ b/src/Network/Socket.cpp
@@ -277,8 +277,12 @@ bool Socket::attachEvent(const SockNum::Ptr &sock) {
     // tcp客户端或udp  [AUTO-TRANSLATED:00c16e7f]
     //TCP client or UDP
     auto read_buffer = _poller->getSharedBuffer(sock->type() == SockNum::Sock_UDP);
-    if (sock->type() == SockNum::Sock_UDP && _read_buffer) {
-        read_buffer = _read_buffer;
+    if (sock->type() == SockNum::Sock_UDP) {
+        LOCK_GUARD(_mtx_sock_fd);
+        _udp_recv_buffer_frozen = true;
+        if (_read_buffer) {
+            read_buffer = _read_buffer;
+        }
     }
     auto result = _poller->addEvent(sock->rawFd(), EventPoller::Event_Read | EventPoller::Event_Error | EventPoller::Event_Write, [weak_self, sock, read_buffer](int event) {
         auto strong_self = weak_self.lock();
@@ -301,6 +305,10 @@ bool Socket::attachEvent(const SockNum::Ptr &sock) {
         }
     });
 
+    if (result == -1 && sock->type() == SockNum::Sock_UDP) {
+        LOCK_GUARD(_mtx_sock_fd);
+        _udp_recv_buffer_frozen = false;
+    }
     return -1 != result;
 }
 
@@ -490,6 +498,7 @@ void Socket::closeSock(bool close_fd) {
         if (close_fd) {
             _err_emit = false;
             _sock_fd = nullptr;
+            _udp_recv_buffer_frozen = false;
         } else if (_sock_fd) {
             _sock_fd->delEvent();
         }
@@ -708,6 +717,7 @@ void Socket::setSock(SockNum::Ptr sock) {
         SockUtil::get_sock_peer_addr(_sock_fd->rawFd(), _peer_addr);
     } else {
         _sock_fd = nullptr;
+        _udp_recv_buffer_frozen = false;
     }
 }
 
@@ -1029,11 +1039,12 @@ void Socket::setSendFlags(int flags) {
 bool Socket::setUdpRecvBuffer(const SocketRecvBuffer::Ptr &buffer) {
     // This hook is setup-time only. UdpServer creation callbacks may run
     // before the owner poller starts processing the fd, so the hard
-    // requirement here is "before fd creation", not "already on poller
-    // thread". The customization itself is only honored for UDP sockets.
+    // requirement here is "before fd creation/attach", not "already on
+    // poller thread". The customization itself is only honored for UDP
+    // sockets.
     LOCK_GUARD(_mtx_sock_fd);
-    if (_sock_fd) {
-        WarnL << "setUdpRecvBuffer must be called before the socket fd is created";
+    if (_sock_fd || _udp_recv_buffer_frozen) {
+        WarnL << "setUdpRecvBuffer must be called before the socket fd is created and UDP IO is attached";
         return false;
     }
     _read_buffer = buffer;

--- a/src/Network/Socket.cpp
+++ b/src/Network/Socket.cpp
@@ -1032,7 +1032,6 @@ bool Socket::setUdpRecvBuffer(const SocketRecvBuffer::Ptr &buffer) {
     // requirement here is "before fd creation", not "already on poller
     // thread". The customization itself is only honored for UDP sockets.
     LOCK_GUARD(_mtx_sock_fd);
-    assert(!_sock_fd);
     if (_sock_fd) {
         WarnL << "setUdpRecvBuffer must be called before the socket fd is created";
         return false;

--- a/src/Network/Socket.cpp
+++ b/src/Network/Socket.cpp
@@ -1026,13 +1026,18 @@ void Socket::setSendFlags(int flags) {
     _sock_flags = flags;
 }
 
-void Socket::setUdpRecvBuffer(const SocketRecvBuffer::Ptr &buffer) {
+bool Socket::setUdpRecvBuffer(const SocketRecvBuffer::Ptr &buffer) {
     // This hook is setup-time only. UdpServer creation callbacks may run
     // before the owner poller starts processing the fd, so the hard
     // requirement here is "before fd creation", not "already on poller
     // thread". The customization itself is only honored for UDP sockets.
     assert(!_sock_fd);
+    if (_sock_fd) {
+        WarnL << "setUdpRecvBuffer must be called before the socket fd is created";
+        return false;
+    }
     _read_buffer = buffer;
+    return true;
 }
 
 void Socket::setIgnoreUdpConnRefused(bool ignore) {

--- a/src/Network/Socket.cpp
+++ b/src/Network/Socket.cpp
@@ -276,18 +276,17 @@ bool Socket::attachEvent(const SockNum::Ptr &sock) {
 
     // tcp客户端或udp  [AUTO-TRANSLATED:00c16e7f]
     //TCP client or UDP
-    auto result = _poller->addEvent(sock->rawFd(), EventPoller::Event_Read | EventPoller::Event_Error | EventPoller::Event_Write, [weak_self, sock](int event) {
+    auto read_buffer = _poller->getSharedBuffer(sock->type() == SockNum::Sock_UDP);
+    if (sock->type() == SockNum::Sock_UDP && _read_buffer) {
+        read_buffer = _read_buffer;
+    }
+    auto result = _poller->addEvent(sock->rawFd(), EventPoller::Event_Read | EventPoller::Event_Error | EventPoller::Event_Write, [weak_self, sock, read_buffer](int event) {
         auto strong_self = weak_self.lock();
         if (!strong_self) {
             return;
         }
 
         if (event & EventPoller::Event_Read) {
-            // Some transports install a socket-specific recv buffer during
-            // session setup after attachEvent() has already been registered, so
-            // the read path must resolve the current buffer here instead of
-            // capturing the poller's shared buffer in the lambda.
-            auto read_buffer = strong_self->getReadBuffer(sock->type() == SockNum::Sock_UDP);
             strong_self->onRead(sock, read_buffer);
         }
         if (event & EventPoller::Event_Write) {
@@ -1027,23 +1026,17 @@ void Socket::setSendFlags(int flags) {
     _sock_flags = flags;
 }
 
-void Socket::setReadBuffer(const SocketRecvBuffer::Ptr &buffer) {
+void Socket::setUdpRecvBuffer(const SocketRecvBuffer::Ptr &buffer) {
+    // This hook is setup-time only. UdpServer creation callbacks may run
+    // before the owner poller starts processing the fd, so the hard
+    // requirement here is "before fd creation", not "already on poller
+    // thread". The customization itself is only honored for UDP sockets.
+    assert(!_sock_fd);
     _read_buffer = buffer;
-    _has_custom_read_buffer.store(static_cast<bool>(_read_buffer), std::memory_order_release);
 }
 
 void Socket::setIgnoreUdpConnRefused(bool ignore) {
     _ignore_udp_conn_refused.store(ignore, std::memory_order_release);
-}
-
-SocketRecvBuffer::Ptr Socket::getReadBuffer(bool is_udp) {
-    // Most sockets keep using the poller's shared recv buffer. Custom buffers
-    // are installed during socket setup, so the hot path only needs a cheap
-    // flag check here.
-    if (!_has_custom_read_buffer.load(std::memory_order_acquire)) {
-        return _poller->getSharedBuffer(is_udp);
-    }
-    return _read_buffer;
 }
 
 ///////////////SockSender///////////////////

--- a/src/Network/Socket.cpp
+++ b/src/Network/Socket.cpp
@@ -1031,6 +1031,7 @@ bool Socket::setUdpRecvBuffer(const SocketRecvBuffer::Ptr &buffer) {
     // before the owner poller starts processing the fd, so the hard
     // requirement here is "before fd creation", not "already on poller
     // thread". The customization itself is only honored for UDP sockets.
+    LOCK_GUARD(_mtx_sock_fd);
     assert(!_sock_fd);
     if (_sock_fd) {
         WarnL << "setUdpRecvBuffer must be called before the socket fd is created";

--- a/src/Network/Socket.h
+++ b/src/Network/Socket.h
@@ -655,14 +655,21 @@ public:
      */
     void setSendFlags(int flags = SOCKET_DEFAULT_FLAGS);
 
-    // Install a transport-specific recv buffer before the socket starts
-    // receiving. This is intended for setup-time tuning, not runtime
-    // reconfiguration after IO callbacks are active.
-    void setReadBuffer(const SocketRecvBuffer::Ptr &buffer);
+    // Install a UDP-specific recv buffer before the socket starts receiving.
+    // This is intended for setup-time tuning, not runtime reconfiguration
+    // after IO callbacks are active.
+    /**
+     * Replace the UDP recv buffer before the socket fd is created/attached.
+     * This is intended for setup-time customization of special UDP transports
+     * and must not be used as a runtime reconfiguration hook.
+     */
+    void setUdpRecvBuffer(const SocketRecvBuffer::Ptr &buffer);
 
     // Suppress the UDP ECONNREFUSED read warning on sockets that intentionally
     // communicate with transient peers, such as QUIC sessions that may receive
-    // a late ICMP port-unreachable after the peer has already closed.
+    // a late ICMP port-unreachable after the peer has already closed. This is
+    // a narrow transport-specific knob and should not be enabled casually by
+    // ordinary upper-layer business code.
     void setIgnoreUdpConnRefused(bool ignore);
 
     /**
@@ -748,8 +755,6 @@ private:
     ssize_t send_l(Buffer::Ptr buf, bool is_buf_sock, bool try_flush = true);
     void connect_l(const std::string &url, uint16_t port, const onErrCB &con_cb_in, float timeout_sec, const std::string &local_ip, uint16_t local_port);
     bool fromSock_l(SockNum::Ptr sock);
-    SocketRecvBuffer::Ptr getReadBuffer(bool is_udp);
-
 private:
     // send socket时的flag  [AUTO-TRANSLATED:e364a1bf]
     //Flag for sending socket
@@ -839,9 +844,8 @@ private:
     ObjectStatistic<Socket> _statistic;
 
     // Optional per-socket recv path used by a small number of UDP transports.
-    // This is configured during socket setup so the default read path does not
-    // pay extra locking cost.
-    std::atomic<bool> _has_custom_read_buffer{false};
+    // This must be configured before the socket fd is created or any IO
+    // callbacks are attached.
     SocketRecvBuffer::Ptr _read_buffer;
     std::atomic<bool> _ignore_udp_conn_refused{false};
 

--- a/src/Network/Socket.h
+++ b/src/Network/Socket.h
@@ -662,8 +662,9 @@ public:
      * Replace the UDP recv buffer before the socket fd is created/attached.
      * This is intended for setup-time customization of special UDP transports
      * and must not be used as a runtime reconfiguration hook.
+     * @return Whether the configuration was accepted.
      */
-    void setUdpRecvBuffer(const SocketRecvBuffer::Ptr &buffer);
+    bool setUdpRecvBuffer(const SocketRecvBuffer::Ptr &buffer);
 
     // Suppress the UDP ECONNREFUSED read warning on sockets that intentionally
     // communicate with transient peers, such as QUIC sessions that may receive

--- a/src/Network/Socket.h
+++ b/src/Network/Socket.h
@@ -662,6 +662,17 @@ public:
      * Replace the UDP recv buffer before the socket fd is created/attached.
      * This is intended for setup-time customization of special UDP transports
      * and must not be used as a runtime reconfiguration hook.
+     *
+     * IMPORTANT: custom SocketRecvBuffer implementations must remain
+     * compatible with the batched UDP receive path used by Socket::onRead().
+     * For the active receive batch, both &buffer->getBuffer(0) and
+     * &buffer->getAddress(0) are treated as pointers to contiguous arrays
+     * that can be indexed up to count - 1, and the referenced storage must
+     * remain valid for the duration of the receive operation.
+     *
+     * Passing a SocketRecvBuffer that does not satisfy this layout/lifetime
+     * contract is unsupported and may lead to undefined behavior.
+     *
      * @return Whether the configuration was accepted.
      */
     bool setUdpRecvBuffer(const SocketRecvBuffer::Ptr &buffer);

--- a/src/Network/Socket.h
+++ b/src/Network/Socket.h
@@ -45,7 +45,7 @@ namespace toolkit {
 
 //默认的socket flags:不触发SIGPIPE,非阻塞发送  [AUTO-TRANSLATED:fefc4946]
 //Default socket flags: do not trigger SIGPIPE, non-blocking send
-#define SOCKET_DEFAULE_FLAGS (FLAG_NOSIGNAL | FLAG_DONTWAIT )
+#define SOCKET_DEFAULT_FLAGS (FLAG_NOSIGNAL | FLAG_DONTWAIT )
     
 //发送超时时间，如果在规定时间内一直没有发送数据成功，那么将触发onErr事件  [AUTO-TRANSLATED:9c5d8d87]
 //Send timeout time, if no data is sent successfully within the specified time, the onErr event will be triggered
@@ -649,7 +649,17 @@ public:
      
      * [AUTO-TRANSLATED:2b11445c]
      */
-    void setSendFlags(int flags = SOCKET_DEFAULE_FLAGS);
+    void setSendFlags(int flags = SOCKET_DEFAULT_FLAGS);
+
+    // Install a transport-specific recv buffer before the socket starts
+    // receiving. This is intended for setup-time tuning, not runtime
+    // reconfiguration after IO callbacks are active.
+    void setReadBuffer(const SocketRecvBuffer::Ptr &buffer);
+
+    // Suppress the UDP ECONNREFUSED read warning on sockets that intentionally
+    // communicate with transient peers, such as QUIC sessions that may receive
+    // a late ICMP port-unreachable after the peer has already closed.
+    void setIgnoreUdpConnRefused(bool ignore);
 
     /**
      * 关闭套接字
@@ -734,11 +744,12 @@ private:
     ssize_t send_l(Buffer::Ptr buf, bool is_buf_sock, bool try_flush = true);
     void connect_l(const std::string &url, uint16_t port, const onErrCB &con_cb_in, float timeout_sec, const std::string &local_ip, uint16_t local_port);
     bool fromSock_l(SockNum::Ptr sock);
+    SocketRecvBuffer::Ptr getReadBuffer(bool is_udp);
 
 private:
     // send socket时的flag  [AUTO-TRANSLATED:e364a1bf]
     //Flag for sending socket
-    int _sock_flags = SOCKET_DEFAULE_FLAGS;
+    int _sock_flags = SOCKET_DEFAULT_FLAGS;
     // 最大发送缓存，单位毫秒，距上次发送缓存清空时间不能超过该参数  [AUTO-TRANSLATED:3bd6dba3]
     //Maximum send buffer, in milliseconds, the time since the last send buffer was cleared cannot exceed this parameter
     uint32_t _max_send_buffer_ms = SEND_TIME_OUT_SEC * 1000;
@@ -822,6 +833,13 @@ private:
     // 对象个数统计  [AUTO-TRANSLATED:f4a012d0]
     //Object count statistics
     ObjectStatistic<Socket> _statistic;
+
+    // Optional per-socket recv path used by a small number of UDP transports.
+    // This is configured during socket setup so the default read path does not
+    // pay extra locking cost.
+    std::atomic<bool> _has_custom_read_buffer{false};
+    SocketRecvBuffer::Ptr _read_buffer;
+    std::atomic<bool> _ignore_udp_conn_refused{false};
 
     // 链接缓存地址,防止tcp reset 导致无法获取对端的地址  [AUTO-TRANSLATED:f8847463]
     //Connection cache address, to prevent TCP reset from causing the inability to obtain the peer's address

--- a/src/Network/Socket.h
+++ b/src/Network/Socket.h
@@ -46,6 +46,10 @@ namespace toolkit {
 //默认的socket flags:不触发SIGPIPE,非阻塞发送  [AUTO-TRANSLATED:fefc4946]
 //Default socket flags: do not trigger SIGPIPE, non-blocking send
 #define SOCKET_DEFAULT_FLAGS (FLAG_NOSIGNAL | FLAG_DONTWAIT )
+// Backward compatibility alias for the legacy misspelled macro name.
+#ifndef SOCKET_DEFAULE_FLAGS
+#define SOCKET_DEFAULE_FLAGS SOCKET_DEFAULT_FLAGS
+#endif
     
 //发送超时时间，如果在规定时间内一直没有发送数据成功，那么将触发onErr事件  [AUTO-TRANSLATED:9c5d8d87]
 //Send timeout time, if no data is sent successfully within the specified time, the onErr event will be triggered

--- a/src/Network/Socket.h
+++ b/src/Network/Socket.h
@@ -859,6 +859,7 @@ private:
     // This must be configured before the socket fd is created or any IO
     // callbacks are attached.
     SocketRecvBuffer::Ptr _read_buffer;
+    bool _udp_recv_buffer_frozen = false;
     std::atomic<bool> _ignore_udp_conn_refused{false};
 
     // 链接缓存地址,防止tcp reset 导致无法获取对端的地址  [AUTO-TRANSLATED:f8847463]

--- a/tests/test_udpSocketBufferConfig.cpp
+++ b/tests/test_udpSocketBufferConfig.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 The ZLToolKit project authors. All Rights Reserved.
  *
  * This file is part of ZLToolKit(https://github.com/ZLMediaKit/ZLToolKit).

--- a/tests/test_udpSocketBufferConfig.cpp
+++ b/tests/test_udpSocketBufferConfig.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2016 The ZLToolKit project authors. All Rights Reserved.
+ *
+ * This file is part of ZLToolKit(https://github.com/ZLMediaKit/ZLToolKit).
+ *
+ * Use of this source code is governed by MIT license that can be found in the
+ * LICENSE file in the root of the source tree. All contributing project authors
+ * may be found in the AUTHORS file in the root of the source tree.
+ */
+
+#include <csignal>
+#include <iostream>
+#include <string>
+
+#include "Network/Socket.h"
+#include "Thread/semaphore.h"
+#include "Util/logger.h"
+#include "Util/util.h"
+
+using namespace std;
+using namespace toolkit;
+
+int main() {
+    Logger::Instance().add(std::make_shared<ConsoleChannel>());
+    Logger::Instance().setWriter(std::make_shared<AsyncLogWriter>());
+
+    auto recv_sock = Socket::createSocket();
+    auto send_sock = Socket::createSocket();
+    if (!recv_sock || !send_sock) {
+        cerr << "create socket failed" << endl;
+        return 1;
+    }
+
+    auto invalid_cfg_buffer = SocketRecvBuffer::create(true, 0, 1);
+    if (!invalid_cfg_buffer) {
+        cerr << "create invalid_cfg_buffer failed" << endl;
+        return 2;
+    }
+
+    if (!recv_sock->setUdpRecvBuffer(invalid_cfg_buffer)) {
+        cerr << "setUdpRecvBuffer should succeed before fd creation" << endl;
+        return 3;
+    }
+
+    recv_sock->setIgnoreUdpConnRefused(true);
+
+    if (!recv_sock->bindUdpSock(0, "127.0.0.1")) {
+        cerr << "bind recv socket failed" << endl;
+        return 4;
+    }
+    if (!send_sock->bindUdpSock(0, "127.0.0.1")) {
+        cerr << "bind send socket failed" << endl;
+        return 5;
+    }
+
+    if (recv_sock->setUdpRecvBuffer(SocketRecvBuffer::create(true, 1, 4096))) {
+        cerr << "setUdpRecvBuffer should fail after fd creation" << endl;
+        return 6;
+    }
+
+    semaphore sem;
+    string received;
+    recv_sock->setOnRead([&](const Buffer::Ptr &buf, struct sockaddr *, int) {
+        received.assign(buf ? buf->data() : "", buf ? buf->size() : 0);
+        sem.post();
+    });
+
+    auto dst = SockUtil::make_sockaddr("127.0.0.1", recv_sock->get_local_port());
+    const string payload = "udp-buffer-config-smoke";
+    if (send_sock->send(payload, reinterpret_cast<struct sockaddr *>(&dst)) <= 0) {
+        cerr << "send payload failed" << endl;
+        return 7;
+    }
+
+    if (!sem.wait(3000)) {
+        cerr << "recv timeout" << endl;
+        return 8;
+    }
+
+    if (received != payload) {
+        cerr << "unexpected payload: " << received << endl;
+        return 9;
+    }
+
+    cout << "udp socket buffer config regression passed" << endl;
+    return 0;
+}


### PR DESCRIPTION
 test_udpEchoServer + test_udpLantencyClient 3 轮对照后：
      - 当前：2250 / 2238 / 2274 ms
      - 父提交：2344 / 2379 / 2186 ms
      - 均值：
          - 当前 2254.0 ms
          - 父提交 2303.0 ms
          - 当前相对父提交 -2.13%
性能稍微有点影响, 现在最终收口后应该语义上不会对现有链路产生影响. 相比第一个提交, 我改进了使用方式.
并且由于增加了公开函数, 所以做了一些验证限制.避免被误用. 另外一个忘记过滤也提交的宏定义也做了兼容处理
