### PR TITLE
修复Windows + wepoll 场景下问题

### DIFF
--- a/src/Poller/EventPoller.cpp
+++ b/src/Poller/EventPoller.cpp
@@ -91,9 +91,23 @@ EventPoller::EventPoller(std::string name) {
 }
 
 void EventPoller::shutdown() {
+#if defined(HAS_EPOLL) && defined(_WIN32)
+    // Windows 平台使用 wepoll，其 epoll_wait 底层基于 IOCP；
+    // 通过写入 pipe 唤醒的方式不一定能可靠地让 epoll_wait 返回，
+    // 直接关闭 epoll 句柄可以强制 epoll_wait 立即出错返回，
+    // 从而避免 join 轮询线程时卡死。
+    // On Windows, wepoll's epoll_wait is backed by IOCP;
+    // closing the epoll handle forces epoll_wait to return immediately,
+    // preventing the shutdown thread from hanging on join().
+    if (_event_fd != INVALID_EVENT_FD) {
+        close_event(_event_fd);
+        _event_fd = INVALID_EVENT_FD;
+    }
+#else
     async_l([]() {
         throw ExitException();
     }, false, true);
+#endif
 
     if (_loop_thread) {
         //防止作为子进程时崩溃  [AUTO-TRANSLATED:68727e34]
@@ -106,7 +120,7 @@ void EventPoller::shutdown() {
 
 EventPoller::~EventPoller() {
     shutdown();
-    
+
 #if defined(HAS_EPOLL) || defined(HAS_KQUEUE)
     if (_event_fd != INVALID_EVENT_FD) {
         close_event(_event_fd);
@@ -387,7 +401,15 @@ void EventPoller::runLoop(bool blocked, bool ref_self) {
             if (ret <= 0) {
                 // 超时或被打断  [AUTO-TRANSLATED:7005fded]
                 // Timed out or interrupted
+#if defined(_WIN32)
+                // Windows 平台使用 wepoll，当 epoll 句柄被关闭后 epoll_wait 会返回错误，
+                // 此时应退出事件循环，避免 join 时卡死。
+                // On Windows with wepoll, epoll_wait returns an error after the epoll
+                // handle is closed, so we should exit the loop to avoid hanging on join.
+                break;
+#else
                 continue;
+#endif
             }
 
             _event_cache_expired.clear();

--- a/src/Poller/EventPoller.cpp
+++ b/src/Poller/EventPoller.cpp
@@ -91,22 +91,26 @@ EventPoller::EventPoller(std::string name) {
 }
 
 void EventPoller::shutdown() {
+    // 首先通过 pipe 投递退出任务，尝试正常唤醒 poller 线程；
+    // 这样 onPipeEvent() 仍有机会被触发，ExitException 也能被正常处理。
+    // First, post the exit task through the pipe to try to wake up the poller
+    // thread normally, so onPipeEvent() still has a chance to be triggered.
+    async_l([]() {
+        throw ExitException();
+    }, false, true);
+
 #if defined(HAS_EPOLL) && defined(_WIN32)
     // Windows 平台使用 wepoll，其 epoll_wait 底层基于 IOCP；
-    // 通过写入 pipe 唤醒的方式不一定能可靠地让 epoll_wait 返回，
-    // 直接关闭 epoll 句柄可以强制 epoll_wait 立即出错返回，
+    // 仅通过写入 pipe 唤醒的方式不一定能可靠地让 epoll_wait 返回，
+    // 因此再关闭 epoll 句柄作为兜底，强制 epoll_wait 立即出错返回，
     // 从而避免 join 轮询线程时卡死。
-    // On Windows, wepoll's epoll_wait is backed by IOCP;
-    // closing the epoll handle forces epoll_wait to return immediately,
-    // preventing the shutdown thread from hanging on join().
+    // On Windows, wepoll's epoll_wait is backed by IOCP; closing the epoll
+    // handle as a fallback forces epoll_wait to return immediately, preventing
+    // the shutdown thread from hanging on join() if the pipe wake-up fails.
     if (_event_fd != INVALID_EVENT_FD) {
         close_event(_event_fd);
         _event_fd = INVALID_EVENT_FD;
     }
-#else
-    async_l([]() {
-        throw ExitException();
-    }, false, true);
 #endif
 
     if (_loop_thread) {


### PR DESCRIPTION
1.修复Windows + wepoll 场景下，不再通过写 pipe 唤醒，而是直接 epoll_close 关闭 wepoll 句柄，强制 epoll_wait 立即返回，从而 join() 不会卡死。2. runLoop() epoll 分支：Windows 下 epoll_wait 返回 <= 0 时直接 break 退出循环；Linux/macOS 保持原来的 continue 行为不变。

同步ZLMediaKit windows环境下无法关闭问题