### PR TITLE
优化网速统计: 改用EMA平滑突发流量导致的速率虚高

### DIFF
--- a/src/Util/SpeedStatistic.h
+++ b/src/Util/SpeedStatistic.h
@@ -11,13 +11,15 @@
 #ifndef SPEED_STATISTIC_H_
 #define SPEED_STATISTIC_H_
 
+#include <cstdint>
 #include "TimeTicker.h"
 
 namespace toolkit {
 
 class BytesSpeed {
 public:
-    BytesSpeed() = default;
+    BytesSpeed(uint64_t window_ms = 5000, uint64_t min_sample_ms = 100, uint64_t init_sample_ms = 1000)
+        : _window_ms(window_ms), _min_sample_ms(min_sample_ms), _init_sample_ms(init_sample_ms) {}
     ~BytesSpeed() = default;
 
     /**
@@ -28,12 +30,7 @@ public:
      */
     BytesSpeed &operator+=(size_t bytes) {
         _bytes += bytes;
-        if (_bytes > 1024 * 1024) {
-            // 数据大于1MB就计算一次网速  [AUTO-TRANSLATED:897af4d6]
-            // Data greater than 1MB is calculated once for network speed
-            computeSpeed();
-        }
-        _total_bytes +=  bytes;
+        _total_bytes += bytes;
         return *this;
     }
 
@@ -44,12 +41,31 @@ public:
      * [AUTO-TRANSLATED:41e26e29]
      */
     size_t getSpeed() {
-        if (_ticker.elapsedTime() < 1000) {
-            // 获取频率小于1秒，那么返回上次计算结果  [AUTO-TRANSLATED:b687b762]
-            // Get frequency less than 1 second, return the last calculation result
+        auto elapsed = _ticker.elapsedTime();
+        if (elapsed < _min_sample_ms) {
+            // 获取频率过高，那么返回上次计算结果
+            // Query too frequently, return the last calculation result
             return _speed;
         }
-        return computeSpeed();
+        auto bytes = _bytes;
+        if (!_has_speed) {
+            if (elapsed < _init_sample_ms) {
+                return 0;
+            }
+            _speed = (size_t)((uint64_t)bytes * 1000 / elapsed);
+        } else if (elapsed >= _window_ms) {
+            _speed = (size_t)((uint64_t)bytes * 1000 / elapsed);
+        } else {
+            // EMA递推: speed += (bytes*1000 - speed*elapsed) / window_ms
+            auto old = (int64_t)_speed;
+            auto diff = (int64_t)((uint64_t)bytes * 1000) - old * (int64_t)elapsed;
+            auto res = old + diff / (int64_t)_window_ms;
+            _speed = (size_t)(res < 0 ? 0 : res);
+        }
+        _bytes = 0;
+        _ticker.resetTime();
+        _has_speed = true;
+        return _speed;
     }
 
     size_t getTotalBytes() const {
@@ -57,21 +73,13 @@ public:
     }
 
 private:
-    size_t computeSpeed() {
-        auto elapsed = _ticker.elapsedTime();
-        if (!elapsed) {
-            return _speed;
-        }
-        _speed = (size_t)(_bytes * 1000 / elapsed);
-        _ticker.resetTime();
-        _bytes = 0;
-        return _speed;
-    }
-
-private:
+    uint64_t _window_ms = 5000;
+    uint64_t _min_sample_ms = 100;
+    uint64_t _init_sample_ms = 1000;
     size_t _speed = 0;
     size_t _bytes = 0;
     size_t _total_bytes = 0;
+    bool _has_speed = false;
     Ticker _ticker;
 };
 


### PR DESCRIPTION
我发现那个pyui的控制面板统计的网速差不多有100倍的的夸张，实际调用的的排查到接口，之前出现1m的包就导致计算一次码率，导致1m/0.06s 得出百兆码率的情况。

旧实现累计超过1MB就用极短时间窗(可能几毫秒)线性外推每秒速率,
遇到I帧等突发数据会把真实速率放大数十倍(如9Mbps显示为124Mbps)。
